### PR TITLE
Copy options object so that we can confidently modify it

### DIFF
--- a/GeoJSON.js
+++ b/GeoJSON.js
@@ -1,8 +1,8 @@
 var GeoJSON = function( geojson, options ){
 
-	var _geometryToGoogleMaps = function( geojsonGeometry, opts, geojsonProperties ){
+	var _geometryToGoogleMaps = function( geojsonGeometry, options, geojsonProperties ){
 		
-		var googleObj;
+		var googleObj, opts = _copy(options);
 		
 		switch ( geojsonGeometry.type ){
 			case "Point":
@@ -176,6 +176,16 @@ var GeoJSON = function( geojson, options ){
 		}
 		return isCCW;
 	};
+  
+  var _copy = function(obj){
+    var newObj = {};
+    for(var i in obj){
+      if(obj.hasOwnProperty(i)){
+        newObj[i] = obj[i];
+      }
+    }
+    return newObj;
+  };
 		
 	var obj;
 	


### PR DESCRIPTION
The options object was being modified by adding paths to it. This is a problem when the options object is reused later.

```
// Options for specifying the style (green border
// and semi-transparent green background)
var polygonOptions = {
  "strokeColor": "#228b22",
  "strokeOpacity": 1,
  "strokeWeight": 3,
  "fillColor": "#228b22",
  "fillOpacity": 0.3
};

// Create a google maps object from geojson. During
// the processing, our options object wasn't being
// copied but instead modified by adding paths to it
var polygon = new GeoJSON(geoJsonData, polygonOptions);

// Later when we update an existing polygon to
// change it's style to green, it's shape and paths
// are also changed because the options object now
// contains path data from the last time it was 
// used by GeoJSON
otherPolygon.setOptions(polygonOptions);
```

This pull request fixes the issue by copying the options object before it gets modified with path data.
