### PR TITLE
Fixed position bug in setInfoWindow

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -405,7 +405,7 @@
 				}
 				content += "</div>";
 				infowindow.setContent(content);
-				infowindow.position = event.latLng;
+				infowindow.setPosition(event.latLng);
 				infowindow.open(map);
 			});
 		}


### PR DESCRIPTION
[minor issue alert]
The setInfoWindow method in index.htm uses `infowindow.position = event.latLng;`, which is rather buggy in the current version of Google Maps. Basically on my polygons it doesn't work until the third click.

Easy fix: use `infowindow.setPosition( event.latLng );`
